### PR TITLE
fix: make GetUsagesByGroups exclude empty model ID usage

### DIFF
--- a/server/internal/store/usage.go
+++ b/server/internal/store/usage.go
@@ -72,6 +72,7 @@ func (s *Store) GetUsagesByGroups(tenantID string, start, end int64) ([]*UsageBy
 			`AVG(latency_ms) AS average_latency`).
 		Where("tenant = ?", tenantID).
 		Where("timestamp >= ? AND timestamp < ?", start, end).
+		Where("model_id <> ?", "").
 		Group("api_key_id,user_id,model_id").
 		Order("api_key_id,user_id,model_id").
 		Scan(&us).Error; err != nil {

--- a/server/internal/store/usage_test.go
+++ b/server/internal/store/usage_test.go
@@ -120,6 +120,18 @@ func TestGetUsagesByGroups(t *testing.T) {
 			PromptTokens:       100,
 			CompletionTokens:   100,
 		},
+		// empty model ID
+		{
+			Tenant:     "t0",
+			APIMethod:  "GetFoo",
+			StatusCode: 200,
+			Timestamp:  start + 201,
+			LatencyMS:  200,
+
+			UserID:   "u10",
+			APIKeyID: "api_key10",
+			ModelID:  "",
+		},
 	}
 	err := st.CreateUsage(usages...)
 	assert.NoError(t, err)


### PR DESCRIPTION
The function is intended for inference requests.